### PR TITLE
Set packageManager to package.json with pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
     "vite": "^5.3.1",
     "vite-plugin-dts": "^3.9.1",
     "vue": "^3.4.29"
-  }
+  },
+  "packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631"
 }


### PR DESCRIPTION
This pull request updates the package.json file to include the pnpm version "pnpm@9.3.0".

This ensures that the correct version of pnpm is used for package management.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for `pnpm` package manager with a specific version.
- **Documentation**
	- Updated `package.json` to include the new `"packageManager"` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->